### PR TITLE
Fix #1, Support scrapy's AWS_* settings

### DIFF
--- a/s3pipeline/pipelines.py
+++ b/s3pipeline/pipelines.py
@@ -29,7 +29,12 @@ class S3Pipeline:
         self.max_chunk_size = settings.getint('S3PIPELINE_MAX_CHUNK_SIZE', 100)
         self.use_gzip = settings.getbool('S3PIPELINE_GZIP', url.endswith('.gz'))
 
-        self.s3 = boto3.client('s3')
+        self.s3 = boto3.client(
+            's3',
+            region_name=settings['AWS_REGION_NAME'], use_ssl=settings['AWS_USE_SSL'],
+            verify=settings['AWS_VERIFY'], endpoint_url=settings['AWS_ENDPOINT_URL'],
+            aws_access_key_id=settings['AWS_ACCESS_KEY_ID'],
+            aws_secret_access_key=settings['AWS_SECRET_ACCESS_KEY'])
         self.items = []
         self.chunk_number = 0
 


### PR DESCRIPTION
Now supports following settings:

* AWS_ACCESS_KEY_ID
* AWS_SECRET_ACCESS_KEY
* AWS_ENDPOINT_URL
* AWS_USE_SSL
* AWS_VERIFY
* AWS_REGION_NAME

See: https://docs.scrapy.org/en/latest/topics/settings.html#aws-access-key-id